### PR TITLE
added <pre> tag for certificate info

### DIFF
--- a/templates/static_analysis.html
+++ b/templates/static_analysis.html
@@ -220,8 +220,9 @@
                                 <h3 class="panel-title"><i class="fa fa-clock-o fa-fw"></i> <span class="glyphicon glyphicon-eye-close"></span> CERTIFICATE</h3>
                             </div>
                             <div class="panel-body">
+                            <pre>
                               {{ certinfo | safe}}
-                                
+                            </pre>
                             </div>
                         </div>
                     </div> 


### PR DESCRIPTION
Certificate info contains lots of text that is better inside a pre tag. 
difference in output will be in terms of spacing and proper alignment.